### PR TITLE
feat: Add cli test for GRD format COG

### DIFF
--- a/src/stactools/sentinel1/grd/commands.py
+++ b/src/stactools/sentinel1/grd/commands.py
@@ -23,9 +23,8 @@ def grd_cmd() -> None:
 def create_collection_command(destination: str) -> None:
     """Creates a STAC Collection for Sentinel1 GRD products"""
 
-    collection = create_collection()
     json_path = os.path.join(destination, "sentinel1-grd.json")
-    collection.set_self_href(os.path.join(os.path.basename(json_path)))
+    collection = create_collection(json_path)
     collection.validate()
     collection.save_object(dest_href=json_path)
 

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -21,7 +21,7 @@ from .properties import fill_sar_properties, fill_sat_properties
 logger = logging.getLogger(__name__)
 
 
-def create_collection() -> pystac.Collection:
+def create_collection(json_path: str) -> pystac.Collection:
     """Creates a STAC Collection for Sentinel-1 RTC"""
     # Lists of all possible values for items
     summary_dict = {
@@ -34,6 +34,7 @@ def create_collection() -> pystac.Collection:
         description=c.SENTINEL_GRD_DESCRIPTION,
         extent=c.SENTINEL_GRD_EXTENT,
         title="Sentinel-1 GRD",
+        href=json_path,
         stac_extensions=[
             SarExtension.get_schema_uri(),
             SatExtension.get_schema_uri(),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,25 @@
+from typing import Sequence, Union
+
+import click
+from click.testing import CliRunner, Result
 from stactools.testing.test_data import TestData
 
+from stactools.sentinel1.commands import create_sentinel1_command
+
 test_data = TestData(__file__)
+
+
+@click.group()
+def test_cli() -> None:
+    pass
+
+
+create_sentinel1_command(test_cli)
+
+
+def run_command(command: Union[str, Sequence[str]]) -> Result:
+    runner = CliRunner()
+    result = runner.invoke(test_cli, command, catch_exceptions=False)
+    if result.output:
+        print(result.output)
+    return result

--- a/tests/grd/test_commands.py
+++ b/tests/grd/test_commands.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+# import pystac
+from pystac import Collection, Item
+
+from tests import run_command, test_data
+
+
+def test_create_collection(tmp_path: Path) -> None:
+    destination = tmp_path / "sentinel1-grd.json"
+    result = run_command(f"sentinel1 grd create-collection {tmp_path}")
+    assert result.exit_code == 0, "\n{}".format(result.output)
+    paths = [p for p in tmp_path.iterdir() if p.suffix == ".json"]
+    assert len(paths) == 1
+    collection = Collection.from_file(str(destination))
+    assert collection.id == "sentinel1-grd"
+    collection.set_self_href(
+        str(destination)
+    )  # Must set the self reference to pass validation
+    collection.validate()
+
+
+def test_create_items(tmp_path: Path) -> None:
+    item_id = "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15"
+
+    infile = test_data.get_path(f"data-files/grd/{item_id}")
+    result = run_command(f"sentinel1 grd create-item {infile} {tmp_path} --format COG")
+    assert result.exit_code == 0, "\n{}".format(result.output)
+
+    paths = [p for p in tmp_path.iterdir() if p.suffix == ".json"]
+    assert len(paths) == 1
+
+    item = Item.from_file(str(tmp_path / paths[0]))
+    item.validate()

--- a/tests/grd/test_stac.py
+++ b/tests/grd/test_stac.py
@@ -19,11 +19,11 @@ class CreateItemTest(CliTestCase):
         return [create_sentinel1_command]
 
     def test_create_collection(self) -> None:
-        collection = stac.create_collection()
+        collection = stac.create_collection("")
         assert isinstance(collection, pystac.Collection)
 
     def test_validate_collection(self) -> None:
-        collection = stac.create_collection()
+        collection = stac.create_collection("")
         collection.normalize_hrefs("./")
         collection.validate()
 


### PR DESCRIPTION
TODO: for some reason collection.set_self_href isn't working and the href is invalid, had to bypass by inserting the path before Collection creation. It passes but not happy with the solution

Before you submit a pull request, please fill in the following:

**Related Issue(s):**
Collection creation was added to the CLI in order to generate a local json easily but it didn't have a test.

**Description:**
In working on the test I discovered that the self/root urls we're statically stuck as the repo root, not where the file actually ends up.
This broke the test. For some reason `set_self_href` isnt' working on Collections (which is inherited from `STACObject`). This PR works around that issue by adding a path arg to the `create_collection`. It's not a great solution.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
